### PR TITLE
[GRDM-34677] ベースイメージ・Shibboleth更新

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -1,0 +1,41 @@
+name: image
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'main'
+      - 'fix/**'
+      - 'feature/**'
+    tags:
+      - 'v*'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Setup GCLOUD
+        uses: google-github-actions/setup-gcloud@v0
+      - name: Set RELEASE_VERSION
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - name: Set IMAGE_TAG
+        run: echo "IMAGE_TAG=$(echo $RELEASE_VERSION | sed 's,/,-,g')" >> $GITHUB_ENV
+      - name: Versions
+        run: |
+          echo GITHUB_REF: "$GITHUB_REF"
+          echo RELEASE_VERSION: "$RELEASE_VERSION"
+          echo IMAGE_TAG: "$IMAGE_TAG"
+      -
+        name: Build and push
+        uses: RafikFarhad/push-to-gcr-github-action@v4
+        with:
+          gcloud_service_key: ${{ secrets.GCLOUD_SERVICE_KEY }}
+          registry: gcr.io
+          project_id: ${{ secrets.GCLOUD_PROJECT_ID }}
+          image_name: ${{ secrets.IMAGE_PREFIX }}shibboleth-sp
+          image_tag: ${{ env.IMAGE_TAG }}
+          dockerfile: ./Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
-FROM centos:centos7
+FROM rockylinux:8
 
-LABEL maintainer="Unicon, Inc."
+LABEL maintainer="Research Center for Open Science and data platform(RCOS) in National Institute of Informatics, Japan"
 
 #See https://docs.shib.ncsu.edu/docs/install/rpmrepos.html
 COPY security:shibboleth.repo /etc/yum.repos.d/security:shibboleth.repo
 
 RUN yum -y update \
-    && yum -y install wget httpd shibboleth-3.3.0-1 mod_ssl \
+    && yum -y install wget httpd shibboleth-3.4.0-1 mod_ssl \
     && yum -y clean all
 
 COPY httpd-shibd-foreground /usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,11 @@ FROM centos:centos7
 
 LABEL maintainer="Unicon, Inc."
 
-#Workaround since OpenSUSE's provo-mirror is not working properly
-#COPY security:shibboleth.repo /etc/yum.repos.d/security:shibboleth.repo
+#See https://docs.shib.ncsu.edu/docs/install/rpmrepos.html
+COPY security:shibboleth.repo /etc/yum.repos.d/security:shibboleth.repo
 
 RUN yum -y update \
-    && yum -y install wget \
-    && wget http://download.opensuse.org/repositories/security://shibboleth/CentOS_7/security:shibboleth.repo -P /etc/yum.repos.d \
-    && yum -y install httpd shibboleth-3.0.4-3.2 mod_ssl \
+    && yum -y install wget httpd shibboleth-3.3.0-1 mod_ssl \
     && yum -y clean all
 
 COPY httpd-shibd-foreground /usr/local/bin/
@@ -27,7 +25,7 @@ RUN test -d /var/run/lock || mkdir -p /var/run/lock \
     && sed -i 's/<\/VirtualHost>/ErrorLogFormat \"httpd-ssl-error [%{u}t] [%-m:%l] [pid %P:tid %T] %7F: %E: [client\\ %a] %M% ,\\ referer\\ %{Referer}i\"\n<\/VirtualHost>/g' /etc/httpd/conf.d/ssl.conf \
     && sed -i 's/CustomLog logs\/ssl_request_log/CustomLog \/dev\/stdout/g' /etc/httpd/conf.d/ssl.conf \
     && sed -i 's/TransferLog logs\/ssl_access_log/TransferLog \/dev\/stdout/g' /etc/httpd/conf.d/ssl.conf
-    
+
 EXPOSE 80 443
 
 CMD ["httpd-shibd-foreground"]

--- a/httpd-shibd-foreground
+++ b/httpd-shibd-foreground
@@ -1,7 +1,12 @@
 #!/bin/bash
 
+set -xe
+
 # Apache and Shibd gets grumpy about PID files pre-existing from previous runs
 rm -f /etc/httpd/run/httpd.pid /var/lock/subsys/shibd
+
+# Generate certificates
+/usr/libexec/httpd-ssl-gencerts
 
 # Make sure /etc/shibboleth/shibd-redhat is executable
 chmod +x /etc/shibboleth/shibd-redhat

--- a/security:shibboleth.repo
+++ b/security:shibboleth.repo
@@ -1,7 +1,8 @@
 [security_shibboleth]
 name=Shibboleth (CentOS_7)
 type=rpm-md
-baseurl=http://anorien.csc.warwick.ac.uk/mirrors/download.opensuse.org/repositories/security:/shibboleth/CentOS_7/
+mirrorlist=https://shibboleth.net/cgi-bin/mirrorlist.cgi/CentOS_7
 gpgcheck=1
-gpgkey=http://anorien.csc.warwick.ac.uk/mirrors/download.opensuse.org/repositories/security:/shibboleth/CentOS_7/repodata/repomd.xml.key
+gpgkey=https://shibboleth.net/downloads/service-provider/RPMS/repomd.xml.key
+        https://shibboleth.net/downloads/service-provider/RPMS/cantor.repomd.xml.key
 enabled=1


### PR DESCRIPTION
パッケージに関するアップグレードを行いました。

- CentOS 7 -> Rocky Linux 8
- Shibboleth 3.0 -> 3.4